### PR TITLE
Add missing return value checks to spdm_hash_all calls.

### DIFF
--- a/library/spdm_common_lib/crypto_service_session.c
+++ b/library/spdm_common_lib/crypto_service_session.c
@@ -54,10 +54,12 @@ boolean spdm_calculate_th_for_exchange(
 	if (cert_chain_buffer != NULL) {
 		DEBUG((DEBUG_INFO, "th_message_ct data :\n"));
 		internal_dump_hex(cert_chain_buffer, cert_chain_buffer_size);
-		spdm_hash_all(
+		if (!spdm_hash_all(
 			spdm_context->connection_info.algorithm.base_hash_algo,
 			cert_chain_buffer, cert_chain_buffer_size,
-			cert_chain_buffer_hash);
+			cert_chain_buffer_hash)) {
+			return FALSE;
+		}
 		status = append_managed_buffer(&th_curr, cert_chain_buffer_hash,
 					       hash_size);
 		if (RETURN_ERROR(status)) {
@@ -141,10 +143,12 @@ boolean spdm_calculate_th_for_finish(IN void *context,
 	if (cert_chain_buffer != NULL) {
 		DEBUG((DEBUG_INFO, "th_message_ct data :\n"));
 		internal_dump_hex(cert_chain_buffer, cert_chain_buffer_size);
-		spdm_hash_all(
+		if (!spdm_hash_all(
 			spdm_context->connection_info.algorithm.base_hash_algo,
 			cert_chain_buffer, cert_chain_buffer_size,
-			cert_chain_buffer_hash);
+			cert_chain_buffer_hash)) {
+			return FALSE;
+		}
 		status = append_managed_buffer(&th_curr, cert_chain_buffer_hash,
 					       hash_size);
 		if (RETURN_ERROR(status)) {
@@ -170,10 +174,12 @@ boolean spdm_calculate_th_for_finish(IN void *context,
 		DEBUG((DEBUG_INFO, "th_message_cm data :\n"));
 		internal_dump_hex(mut_cert_chain_buffer,
 				  mut_cert_chain_buffer_size);
-		spdm_hash_all(
+		if (!spdm_hash_all(
 			spdm_context->connection_info.algorithm.base_hash_algo,
 			mut_cert_chain_buffer, mut_cert_chain_buffer_size,
-			mut_cert_chain_buffer_hash);
+			mut_cert_chain_buffer_hash)) {
+			return FALSE;
+		}
 		status = append_managed_buffer(&th_curr, mut_cert_chain_buffer_hash,
 					       hash_size);
 		if (RETURN_ERROR(status)) {
@@ -246,8 +252,12 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
 	}
 
 	// debug only
-	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
+	result = spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, hash_data);
+	if (!result) {
+		DEBUG((DEBUG_INFO, "th_curr hash calculation failed!\n"));
+		return result;
+	}
 	DEBUG((DEBUG_INFO, "th_curr hash - "));
 	internal_dump_data(hash_data, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));
@@ -362,8 +372,12 @@ boolean spdm_verify_key_exchange_rsp_signature(
 	}
 
 	// debug only
-	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
+	result = spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, hash_data);
+	if (!result) {
+		DEBUG((DEBUG_INFO, "th_curr hash calculation failed!\n"));
+		return result;
+	}
 	DEBUG((DEBUG_INFO, "th_curr hash - "));
 	internal_dump_data(hash_data, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));
@@ -522,8 +536,12 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
 	}
 
 	// debug only
-	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
+	result = spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, hash_data);
+	if (!result) {
+		DEBUG((DEBUG_INFO, "th_curr hash calculation failed!\n"));
+		return result;
+	}
 	DEBUG((DEBUG_INFO, "th_curr hash - "));
 	internal_dump_data(hash_data, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));
@@ -664,8 +682,12 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
 	}
 
 	// debug only
-	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
+	result = spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, hash_data);
+	if (!result) {
+		DEBUG((DEBUG_INFO, "th_curr hash calculation failed!\n"));
+		return result;
+	}
 	DEBUG((DEBUG_INFO, "th_curr hash - "));
 	internal_dump_data(hash_data, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));
@@ -1170,8 +1192,12 @@ return_status spdm_calculate_th1_hash(IN void *context,
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
+	result = spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, th1_hash_data);
+	if (!result) {
+		DEBUG((DEBUG_INFO, "th1 hash calculation failed!\n"));
+		return result;
+	}
 	DEBUG((DEBUG_INFO, "th1 hash - "));
 	internal_dump_data(th1_hash_data, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));
@@ -1262,8 +1288,12 @@ return_status spdm_calculate_th2_hash(IN void *context,
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
+	result = spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, th2_hash_data);
+	if (!result) {
+		DEBUG((DEBUG_INFO, "th2 hash calculation failed!\n"));
+		return result;
+	}
 	DEBUG((DEBUG_INFO, "th2 hash - "));
 	internal_dump_data(th2_hash_data, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));

--- a/library/spdm_crypt_lib/crypt.c
+++ b/library/spdm_crypt_lib/crypt.c
@@ -2567,8 +2567,11 @@ boolean spdm_verify_certificate_chain_buffer(IN uint32 base_hash_algo,
 	}
 
 	if (spdm_is_root_certificate(first_cert_buffer, first_cert_buffer_size)) {
-		spdm_hash_all(base_hash_algo, first_cert_buffer, first_cert_buffer_size,
-				calc_root_cert_hash);
+		if (!spdm_hash_all(base_hash_algo, first_cert_buffer, first_cert_buffer_size,
+				calc_root_cert_hash)) {
+		DEBUG((DEBUG_INFO,
+		       "!!! VerifyCertificateChainBuffer - FAIL (calculate cert root hash failed)!!!\n"));
+		}
 		if (const_compare_mem((uint8 *)cert_chain_buffer + sizeof(spdm_cert_chain_t),
 				calc_root_cert_hash, hash_size) != 0) {
 			DEBUG((DEBUG_INFO,

--- a/os_stub/spdm_device_secret_lib/cert.c
+++ b/os_stub/spdm_device_secret_lib/cert.c
@@ -85,8 +85,14 @@ boolean read_responder_root_public_certificate(IN uint32 base_hash_algo,
 	cert_chain->length = (uint16)cert_chain_size;
 	cert_chain->reserved = 0;
 
-	spdm_hash_all(base_hash_algo, file_data, file_size,
+	res = spdm_hash_all(base_hash_algo, file_data, file_size,
 		      (uint8 *)(cert_chain + 1));
+	if (!res) {
+		free(file_data);
+		free(cert_chain);
+		return res;
+	}
+
 	copy_mem((uint8 *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
 		 file_data, file_size);
 
@@ -165,8 +171,15 @@ boolean read_requester_root_public_certificate(IN uint32 base_hash_algo,
 	}
 	cert_chain->length = (uint16)cert_chain_size;
 	cert_chain->reserved = 0;
-	spdm_hash_all(base_hash_algo, file_data, file_size,
+
+	res = spdm_hash_all(base_hash_algo, file_data, file_size,
 		      (uint8 *)(cert_chain + 1));
+	if (!res) {
+		free(file_data);
+		free(cert_chain);
+		return res;
+	}
+
 	copy_mem((uint8 *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
 		 file_data, file_size);
 
@@ -263,8 +276,14 @@ boolean read_responder_public_certificate_chain(
 		return res;
 	}
 
-	spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
+	res = spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
 		      (uint8 *)(cert_chain + 1));
+	if (!res) {
+		free(file_data);
+		free(cert_chain);
+		return res;
+	}
+
 	copy_mem((uint8 *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
 		 file_data, file_size);
 
@@ -361,8 +380,14 @@ boolean read_requester_public_certificate_chain(
 		return res;
 	}
 
-	spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
+	res = spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
 		      (uint8 *)(cert_chain + 1));
+	if (!res) {
+		free(file_data);
+		free(cert_chain);
+		return res;
+	}
+
 	copy_mem((uint8 *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
 		 file_data, file_size);
 
@@ -433,8 +458,14 @@ boolean read_responder_root_public_certificate_by_size(
 	cert_chain->length = (uint16)cert_chain_size;
 	cert_chain->reserved = 0;
 
-	spdm_hash_all(base_hash_algo, file_data, file_size,
+	res = spdm_hash_all(base_hash_algo, file_data, file_size,
 		      (uint8 *)(cert_chain + 1));
+	if (!res) {
+		free(file_data);
+		free(cert_chain);
+		return res;
+	}
+
 	copy_mem((uint8 *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
 		 file_data, file_size);
 
@@ -525,8 +556,14 @@ boolean read_responder_public_certificate_chain_by_size(
 		return res;
 	}
 
-	spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
+	res = spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
 		      (uint8 *)(cert_chain + 1));
+	if (!res) {
+		free(file_data);
+		free(cert_chain);
+		return res;
+	}
+
 	copy_mem((uint8 *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
 		 file_data, file_size);
 


### PR DESCRIPTION
Addresses #75. Adds return value checking to spdm_hash_all to ensure we are not missing errors.

Will handle other functions in separate CL's to limit scope. That way, it is easier to review and ensure there are no unintended changes to program flow.