### PR TITLE
Modifying return value handling for random_bytes and spdm_get_random_number.

### DIFF
--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -1000,8 +1000,11 @@ boolean spdm_aead_decryption(IN uint16 aead_cipher_suite, IN const uint8 *key,
   @param  spdm_context                  A pointer to the SPDM context.
   @param  size                         size of random bytes to generate.
   @param  rand                         Pointer to buffer to receive random value.
+
+  @retval  TRUE   random number generation success.
+  @retval  FALSE  random number generation fail.
 **/
-void spdm_get_random_number(IN uintn size, OUT uint8 *rand);
+boolean spdm_get_random_number(IN uintn size, OUT uint8 *rand);
 
 /**
   Certificate Check for SPDM leaf cert.

--- a/library/spdm_crypt_lib/crypt.c
+++ b/library/spdm_crypt_lib/crypt.c
@@ -2076,12 +2076,13 @@ boolean spdm_aead_decryption(IN uint16 aead_cipher_suite, IN const uint8 *key,
   @param  spdm_context                  A pointer to the SPDM context.
   @param  size                         size of random bytes to generate.
   @param  rand                         Pointer to buffer to receive random value.
-**/
-void spdm_get_random_number(IN uintn size, OUT uint8 *rand)
-{
-	random_bytes(rand, size);
 
-	return;
+  @retval  TRUE   random number generation success.
+  @retval  FALSE  random number generation fail.
+**/
+boolean spdm_get_random_number(IN uintn size, OUT uint8 *rand)
+{
+	return random_bytes(rand, size);
 }
 
 /**

--- a/library/spdm_requester_lib/challenge.c
+++ b/library/spdm_requester_lib/challenge.c
@@ -91,7 +91,10 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 	spdm_request.header.request_response_code = SPDM_CHALLENGE;
 	spdm_request.header.param1 = slot_id;
 	spdm_request.header.param2 = measurement_hash_type;
-	spdm_get_random_number(SPDM_NONCE_SIZE, spdm_request.nonce);
+	result = spdm_get_random_number(SPDM_NONCE_SIZE, spdm_request.nonce);
+	if (!result) {
+		return RETURN_DEVICE_ERROR;
+	}
 	DEBUG((DEBUG_INFO, "ClientNonce - "));
 	internal_dump_data(spdm_request.nonce, SPDM_NONCE_SIZE);
 	DEBUG((DEBUG_INFO, "\n"));

--- a/library/spdm_requester_lib/encap_challenge_auth.c
+++ b/library/spdm_requester_lib/encap_challenge_auth.c
@@ -111,7 +111,12 @@ return_status spdm_get_encap_response_challenge_auth(
 	spdm_generate_cert_chain_hash(spdm_context, slot_id, ptr);
 	ptr += hash_size;
 
-	spdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+	result = spdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+	if (!result) {
+		return spdm_generate_encap_error_response(
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
+			response_size, response);
+	}
 	ptr += SPDM_NONCE_SIZE;
 
 	ptr += measurement_summary_hash_size;

--- a/library/spdm_requester_lib/get_measurements.c
+++ b/library/spdm_requester_lib/get_measurements.c
@@ -146,7 +146,10 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 					    sizeof(spdm_request.SlotIDParam);
 		}
 
-		spdm_get_random_number(SPDM_NONCE_SIZE, spdm_request.nonce);
+		result = spdm_get_random_number(SPDM_NONCE_SIZE, spdm_request.nonce);
+		if (!result) {
+			return RETURN_DEVICE_ERROR;
+		}
 		DEBUG((DEBUG_INFO, "ClientNonce - "));
 		internal_dump_data(spdm_request.nonce, SPDM_NONCE_SIZE);
 		DEBUG((DEBUG_INFO, "\n"));

--- a/library/spdm_requester_lib/key_exchange.c
+++ b/library/spdm_requester_lib/key_exchange.c
@@ -102,7 +102,11 @@ return_status try_spdm_send_receive_key_exchange(
 	spdm_request.header.request_response_code = SPDM_KEY_EXCHANGE;
 	spdm_request.header.param1 = measurement_hash_type;
 	spdm_request.header.param2 = slot_id;
-	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE, spdm_request.random_data);
+	result = spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
+		spdm_request.random_data);
+	if (!result) {
+		return RETURN_DEVICE_ERROR;
+	}
 	DEBUG((DEBUG_INFO, "ClientRandomData (0x%x) - ",
 	       SPDM_RANDOM_DATA_SIZE));
 	internal_dump_data(spdm_request.random_data, SPDM_RANDOM_DATA_SIZE);

--- a/library/spdm_requester_lib/key_update.c
+++ b/library/spdm_requester_lib/key_update.c
@@ -28,6 +28,7 @@ return_status spdm_key_update(IN void *context, IN uint32 session_id,
 	spdm_key_update_request_t spdm_request;
 	spdm_key_update_response_t spdm_response;
 	uintn spdm_response_size;
+	boolean result;
 	spdm_key_update_action_t action;
 	spdm_context_t *spdm_context;
 	spdm_session_info_t *session_info;
@@ -77,8 +78,11 @@ return_status spdm_key_update(IN void *context, IN uint32 session_id,
 			SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS;
 	}
 	spdm_request.header.param2 = 0;
-	spdm_get_random_number(sizeof(spdm_request.header.param2),
+	result = spdm_get_random_number(sizeof(spdm_request.header.param2),
 			       &spdm_request.header.param2);
+	if (!result) {
+		return RETURN_DEVICE_ERROR;
+	}
 
 	// Create new key
 	if ((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) {
@@ -147,8 +151,11 @@ return_status spdm_key_update(IN void *context, IN uint32 session_id,
 	spdm_request.header.param1 =
 		SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
 	spdm_request.header.param2 = 1;
-	spdm_get_random_number(sizeof(spdm_request.header.param2),
+	result = spdm_get_random_number(sizeof(spdm_request.header.param2),
 			       &spdm_request.header.param2);
+	if (!result) {
+		return RETURN_DEVICE_ERROR;
+	}
 
 	status = spdm_send_spdm_request(spdm_context, &session_id,
 					sizeof(spdm_request), &spdm_request);

--- a/library/spdm_requester_lib/psk_exchange.c
+++ b/library/spdm_requester_lib/psk_exchange.c
@@ -136,7 +136,10 @@ return_status try_spdm_send_receive_psk_exchange(
 	DEBUG((DEBUG_INFO, "\n"));
 	ptr += spdm_request.psk_hint_length;
 
-	spdm_get_random_number(DEFAULT_CONTEXT_LENGTH, ptr);
+	result = spdm_get_random_number(DEFAULT_CONTEXT_LENGTH, ptr);
+	if (!result) {
+		return RETURN_DEVICE_ERROR;
+	}
 	DEBUG((DEBUG_INFO, "ClientRandomData (0x%x) - ",
 	       spdm_request.context_length));
 	internal_dump_data(ptr, spdm_request.context_length);

--- a/library/spdm_responder_lib/challenge_auth.c
+++ b/library/spdm_responder_lib/challenge_auth.c
@@ -160,7 +160,12 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	spdm_generate_cert_chain_hash(spdm_context, slot_id, ptr);
 	ptr += hash_size;
 
-	spdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+	result = spdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+	if (!result) {
+		return spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+	}
 	ptr += SPDM_NONCE_SIZE;
 
 	result = spdm_generate_measurement_summary_hash(

--- a/library/spdm_responder_lib/encap_challenge.c
+++ b/library/spdm_responder_lib/encap_challenge.c
@@ -25,6 +25,7 @@ return_status spdm_get_encap_request_challenge(IN spdm_context_t *spdm_context,
 {
 	spdm_challenge_request_t *spdm_request;
 	return_status status;
+	boolean result;
 
 	spdm_context->encap_context.last_encap_request_size = 0;
 
@@ -48,7 +49,10 @@ return_status spdm_get_encap_request_challenge(IN spdm_context_t *spdm_context,
 	spdm_request->header.param1 = spdm_context->encap_context.req_slot_id;
 	spdm_request->header.param2 =
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH;
-	spdm_get_random_number(SPDM_NONCE_SIZE, spdm_request->nonce);
+	result = spdm_get_random_number(SPDM_NONCE_SIZE, spdm_request->nonce);
+	if (!result) {
+		return RETURN_DEVICE_ERROR;
+	}
 	DEBUG((DEBUG_INFO, "Encap ClientNonce - "));
 	internal_dump_data(spdm_request->nonce, SPDM_NONCE_SIZE);
 	DEBUG((DEBUG_INFO, "\n"));

--- a/library/spdm_responder_lib/encap_key_update.c
+++ b/library/spdm_responder_lib/encap_key_update.c
@@ -26,6 +26,7 @@ spdm_get_encap_request_key_update(IN spdm_context_t *spdm_context,
 {
 	spdm_key_update_request_t *spdm_request;
 	uint32 session_id;
+	boolean result;
 	spdm_session_info_t *session_info;
 	spdm_session_state_t session_state;
 
@@ -69,14 +70,20 @@ spdm_get_encap_request_key_update(IN spdm_context_t *spdm_context,
 		spdm_request->header.param1 =
 			SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
 		spdm_request->header.param2 = 0;
-		spdm_get_random_number(sizeof(spdm_request->header.param2),
+		result = spdm_get_random_number(sizeof(spdm_request->header.param2),
 				       &spdm_request->header.param2);
+		if (!result) {
+			return RETURN_DEVICE_ERROR;
+		}
 	} else {
 		spdm_request->header.param1 =
 			SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
 		spdm_request->header.param2 = 1;
-		spdm_get_random_number(sizeof(spdm_request->header.param2),
+		result = spdm_get_random_number(sizeof(spdm_request->header.param2),
 				       &spdm_request->header.param2);
+		if (!result) {
+			return RETURN_DEVICE_ERROR;
+		}
 
 		// Create new key
 		DEBUG((DEBUG_INFO,

--- a/library/spdm_responder_lib/key_exchange.c
+++ b/library/spdm_responder_lib/key_exchange.c
@@ -212,8 +212,14 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		spdm_response->req_slot_id_param = 0;
 	}
 
-	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
+	result = spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
 			       spdm_response->random_data);
+	if (!result) {
+		spdm_free_session_id(spdm_context, session_id);
+		return spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+	}
 
 	ptr = (void *)(spdm_response + 1);
 	dhe_context = spdm_secured_message_dhe_new(

--- a/library/spdm_responder_lib/psk_exchange.c
+++ b/library/spdm_responder_lib/psk_exchange.c
@@ -244,7 +244,12 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	ptr += measurement_summary_hash_size;
 
 	if (context_length != 0) {
-		spdm_get_random_number(context_length, ptr);
+		result = spdm_get_random_number(context_length, ptr);
+		if (!result) {
+			return spdm_generate_error_response(spdm_context,
+					SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					response_size, response);
+		}
 		ptr += context_length;
 	}
 

--- a/library/spdm_secured_message_lib/encode_decode.c
+++ b/library/spdm_secured_message_lib/encode_decode.c
@@ -179,7 +179,11 @@ return_status spdm_encode_secured_message(
 					 ->get_max_random_number_count();
 		if (max_rand_count != 0) {
 			rand_count = 0;
-			random_bytes((uint8 *)&rand_count, sizeof(rand_count));
+			result = spdm_get_random_number(sizeof(rand_count),
+				(uint8 *)&rand_count);
+			if (!result) {
+				return RETURN_DEVICE_ERROR;
+			}
 			rand_count = (uint8)((rand_count % max_rand_count) + 1);
 		} else {
 			rand_count = 0;
@@ -212,11 +216,13 @@ return_status spdm_encode_secured_message(
 		enc_msg_header->application_data_length =
 			(uint16)app_message_size;
 		copy_mem(enc_msg_header + 1, app_message, app_message_size);
-		random_bytes(
+		result = spdm_get_random_number(rand_count,
 			(uint8 *)enc_msg_header +
-				sizeof(spdm_secured_message_cipher_header_t) +
-				app_message_size,
-			rand_count);
+			sizeof(spdm_secured_message_cipher_header_t) +
+			app_message_size);
+		if (!result) {
+			return RETURN_DEVICE_ERROR;
+		}
 		zero_mem((uint8 *)enc_msg_header + plain_text_size,
 			 aead_pad_size);
 

--- a/os_stub/cryptlib_mbedtls/rand/rand.c
+++ b/os_stub/cryptlib_mbedtls/rand/rand.c
@@ -74,7 +74,9 @@ boolean random_bytes(OUT uint8 *output, IN uintn size)
 
 int myrand(void *rng_state, unsigned char *output, size_t len)
 {
-	random_bytes(output, len);
+	boolean success;
 
-	return 0;
+	success = random_bytes(output, len);
+
+	return success ? 0 : -1;
 }

--- a/os_stub/cryptlib_mbedtls/rand/rand.c
+++ b/os_stub/cryptlib_mbedtls/rand/rand.c
@@ -78,5 +78,10 @@ int myrand(void *rng_state, unsigned char *output, size_t len)
 
 	success = random_bytes(output, len);
 
+	//
+	// Random function f_rng (which myrand implements) is not documented
+	// in mbedtls code. From looking at mbedtls code, it interprets 0 as
+	// success, and nonzero as failure, so we use that convention here.
+	//
 	return success ? 0 : -1;
 }


### PR DESCRIPTION
Addresses #75.

Adds checks for random_bytes return value, and adds a return type to spdm_get_random_number, so that failures in the function are not ignored.  Updates functions calling spdm_get_random_number to match new return type.

Part of a series of changes to improve libspdm return value handling.
Signed-off-by: Timothy Prinz <82243378+taprinz@users.noreply.github.com>